### PR TITLE
Initial FreeBSD support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ This module has been tested to work on the following systems.
 * Ubuntu 10.04
 * Ubuntu 12.04
 * Ubuntu 14.04
+* FreeBSD 10.2
 
 ===
 

--- a/lib/facter/python_version.rb
+++ b/lib/facter/python_version.rb
@@ -2,7 +2,10 @@
 
 def get_python_version(executable)
   if Facter::Util::Resolution.which(executable)
-    Facter::Util::Resolution.exec("#{executable} -V 2>&1").match(/^.*(\d+\.\d+\.\d+)$/)[1]
+    results = Facter::Util::Resolution.exec("#{executable} -V 2>&1").match(/^.*(\d+\.\d+\.\d+)$/)
+    if results
+      results[1]
+    end
   end
 end
 

--- a/manifests/dotfile.pp
+++ b/manifests/dotfile.pp
@@ -39,7 +39,7 @@ define python::dotfile (
   $ensure   = 'present',
   $filename = $title,
   $owner    = 'root',
-  $group    = 'root',
+  $group    = '0',
   $mode     = '0644',
   $config   = {},
 ) {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -98,7 +98,7 @@ class python (
   validate_bool($use_epel)
 
   # Module compatibility check
-  $compatible = [ 'Debian', 'RedHat', 'Suse' ]
+  $compatible = [ 'Debian', 'RedHat', 'Suse', 'FreeBSD' ]
   if ! ($::osfamily in $compatible) {
     fail("Module is not compatible with ${::operatingsystem}")
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,9 +11,10 @@ class python::params {
   $manage_gunicorn        = true
   $provider               = undef
   $valid_versions = $::osfamily ? {
-    'RedHat' => ['3'],
-    'Debian' => ['3', '3.3', '2.7'],
-    'Suse'   => [],
+    'RedHat'  => ['3'],
+    'Debian'  => ['3', '3.3', '2.7'],
+    'Suse'    => [],
+    'FreeBSD' => ['3', '34', '2', '27']
   }
   $use_epel               = true
 }

--- a/manifests/pyvenv.pp
+++ b/manifests/pyvenv.pp
@@ -53,7 +53,7 @@ define python::pyvenv (
   $systempkgs       = false,
   $venv_dir         = $name,
   $owner            = 'root',
-  $group            = 'root',
+  $group            = '0',
   $mode             = '0755',
   $path             = [ '/bin', '/usr/bin', '/usr/sbin', '/usr/local/bin' ],
   $environment      = [],

--- a/manifests/requirements.pp
+++ b/manifests/requirements.pp
@@ -64,7 +64,7 @@ define python::requirements (
   $requirements           = $name,
   $virtualenv             = 'system',
   $owner                  = 'root',
-  $group                  = 'root',
+  $group                  = '0',
   $proxy                  = false,
   $src                    = false,
   $environment            = [],
@@ -76,7 +76,7 @@ define python::requirements (
   $timeout                = 1800,
 ) {
 
-  if $virtualenv == 'system' and ($owner != 'root' or $group != 'root') {
+  if $virtualenv == 'system' and ($owner != 'root' or $group != '0') {
     fail('python::pip: root user must be used when virtualenv is system')
   }
 

--- a/manifests/virtualenv.pp
+++ b/manifests/virtualenv.pp
@@ -77,7 +77,7 @@ define python::virtualenv (
   $distribute       = true,
   $index            = false,
   $owner            = 'root',
-  $group            = 'root',
+  $group            = '0',
   $mode             = '0755',
   $proxy            = false,
   $environment      = [],

--- a/metadata.json
+++ b/metadata.json
@@ -44,6 +44,12 @@
       "operatingsystemrelease": [
         "11.3"
       ]
+    },
+    {
+      "operatingsystem": "FreeBSD",
+      "operatingsystemrelease": [
+        "10.2"
+      ]
     }
   ],
   "requirements": [

--- a/spec/defines/requirements_spec.rb
+++ b/spec/defines/requirements_spec.rb
@@ -38,7 +38,7 @@ describe 'python::requirements', :type => :define do
 
       describe "with owner" do
         context "default" do
-          it { is_expected.to contain_file("/requirements.txt").with_owner('root').with_group('root') }
+          it { is_expected.to contain_file("/requirements.txt").with_owner('root').with_group('0') }
         end
       end
     end


### PR DESCRIPTION
Here is the result of my effort to get Python managed on my FreeBSD systems. Python 3 has some edge cases, and lacks packages for a few items on FreeBSD, so there is some logic to work around some of this. I tried to keep it as clean as I could and still keep the main structure of the module. See the commits for more information.