### PR TITLE
Improve virtualenv + pip handling on CentOS

### DIFF
--- a/functions/ensure_pip.pp
+++ b/functions/ensure_pip.pp
@@ -9,7 +9,7 @@ function python::ensure_pip($ensure) {
         exec { 'install_pip3':
           command => '/usr/local/bin/python3 -m ensurepip',
           creates => '/usr/local/bin/pip3',
-          require => Package[$python::install::python],
+          require => Package[$python::install::python_name],
         }
 
         file { '/usr/local/bin/pip':
@@ -23,15 +23,18 @@ function python::ensure_pip($ensure) {
       if $ensure == present {
         if $python::use_epel == true {
           include 'epel'
-          Class['epel'] -> Package[$pip_name]
+          #Class['epel'] -> Package[$pip_name]
         }
       }
-      if ($::python::install::virtualenv_ensure == present) and ($facts['os']['release']['major'] =~ /^6/) {
-        if $python::use_epel == true {
-          include 'epel'
-          Class['epel'] -> Package[$python::virtualenv::python_virtualenv]
+
+      if $ensure == present and $::python::version =~ /^3/ {
+        exec { 'install_pip3':
+          command => '/bin/curl https://bootstrap.pypa.io/get-pip.py | /bin/python3',
+          creates => '/bin/pip3',
+          require => Package[$python::install::python_name],
         }
       }
+
     }
   }
 

--- a/functions/ensure_virtualenv.pp
+++ b/functions/ensure_virtualenv.pp
@@ -1,0 +1,41 @@
+function python::ensure_virtualenv($ensure) {
+
+  $virtualenv_name = python::virtualenv_name()
+
+  if $virtualenv_name {
+    if $facts['osfamily'] == 'FreeBSD' and $::python::version =~ /^3/ {
+      if $ensure == 'present' {
+        python::require_pip()
+        package { $virtualenv_name:
+          ensure   => $ensure,
+          provider => 'pip',
+          require  => Exec['install_pip3'],
+        }
+      } else {
+        package { $virtualenv_name:
+          ensure   => $ensure,
+          provider => 'pip',
+        }
+      }
+    } elsif $facts['osfamily'] == 'RedHat' and $::python::version =~ /^3/ {
+      if $ensure == 'present' {
+        python::require_pip()
+        package { $virtualenv_name:
+          ensure   => $ensure,
+          provider => 'pip3',
+          require  => Exec['install_pip3'],
+        }
+      } else {
+        package { $virtualenv_name:
+          ensure   => $ensure,
+          provider => 'pip3',
+        }
+      }
+    } else {
+      package { $virtualenv_name:
+        ensure  => $ensure,
+        require => Package[$python::install::python_name],
+      }
+    }
+  }
+}

--- a/functions/pip_name.pp
+++ b/functions/pip_name.pp
@@ -7,11 +7,8 @@ function python::pip_name() {
         $pip_name = 'python-pip'
       } elsif $::python::version =~ /^3/ {
         if $facts['osfamily'] == 'RedHat' {
-          if $::os['release']['major'] == '7' {
-            $pip_name = 'python-pip'
-          } else {
-            $pip_name = 'python3-pip'
-          }
+          # As of 2016-05-31 RedHat osfamilies curl get-pip.py to install python3
+          $pip_name = undef
         } else {
           $pip_name = 'python3-pip'
         }

--- a/functions/require_pip.pp
+++ b/functions/require_pip.pp
@@ -1,0 +1,12 @@
+# This function handles the logic of checking if pip is enabled on the python
+# class and failing if it is not.  This allows the user to require that pip is
+# installed in a clean way and allow for consistent messaging.
+#
+# @example
+#   python::require_pip()
+#
+function python::require_pip() {
+  unless $::python::pip {
+    fail("Installing virtualenv on ${::operatingsystem} ${::operatingsystemmajrelease} with ${::python::version} requires that 'python::pip' be set true")
+  }
+}

--- a/functions/virtualenv_name.pp
+++ b/functions/virtualenv_name.pp
@@ -3,16 +3,32 @@
 function python::virtualenv_name() {
   case $facts['kernel'] {
     'Linux': {
-      $python_virtualenv = $facts['operatingsystemmajrelease'] ? {
-        '8'     => 'virtualenv',
-        default => 'python-virtualenv',
+      if $facts['operatingisystem'] == 'Debian' {
+        if $::python::version =~ /^3/ {
+          $virtualenv_name = 'python3-virtualenv'
+        } else {
+          $virtualenv_name = 'python-virtualenv'
+        }
+      } elsif $facts['osfamily'] == 'RedHat' {
+        if $::python::version =~ /^3/ {
+          # Use the pip name when on python3
+          $virtualenv_name = 'virtualenv'
+        } else {
+          $virtualenv_name = 'python-virtualenv'
+        }
+      } else {
+        if $::python::version =~ /^3/ {
+          $virtualenv_name = 'python3-virtualenv'
+        } else {
+          $virtualenv_name = 'python-virtualenv'
+        }
       }
     }
     'FreeBSD': {
       if $::python::version =~ /^3/ {
-        $python_virtualenv = 'virtualenv'
+        $virtualenv_name = 'virtualenv'
       } else {
-        $python_virtualenv = 'py27-virtualenv'
+        $virtualenv_name = 'py27-virtualenv'
       }
     }
   }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -19,22 +19,9 @@ class python::install {
     default => absent,
   }
 
-  $python_virtualenv = python::virtualenv_name()
   $virtualenv_ensure = $python::virtualenv ? {
     true    => present,
     default => absent,
-  }
-
-  if $python_virtualenv {
-    if $::osfamily == 'FreeBSD' and $::python::version =~ /^3/ {
-      package { $python_virtualenv:
-        ensure   => $virtualenv_ensure,
-        provider => 'pip',
-        require  => Exec['install_pip3'],
-      }
-    } else {
-      package { $python_virtualenv: ensure => $virtualenv_ensure }
-    }
   }
 
   if $python_dev {
@@ -47,7 +34,7 @@ class python::install {
   }
 
   python::ensure_pip($pip_ensure)
-
+  python::ensure_virtualenv($virtualenv_ensure)
 
   case $facts['kernel'] {
     'OpenBSD': {

--- a/manifests/virtualenv.pp
+++ b/manifests/virtualenv.pp
@@ -92,9 +92,14 @@ define python::virtualenv (
     }
 
     if $virtualenv == undef {
-      $used_virtualenv = $version ? {
-        'system' => 'virtualenv',
-        default  => "virtualenv-${version}",
+
+      if $facts['osfamily'] == 'RedHat' {
+        $used_virtualenv = 'virtualenv'
+      } else {
+        $used_virtualenv = $version ? {
+          'system' => 'virtualenv',
+          default  => "virtualenv-${version}",
+        }
       }
     } else {
       $used_virtualenv = $virtualenv

--- a/metadata.json
+++ b/metadata.json
@@ -24,8 +24,7 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "8",
-        "7"
+        "8"
       ]
     },
     {
@@ -45,7 +44,6 @@
       "operatingsystem": "FreeBSD",
       "operatingsystemrelease": [
         "10.3"
-
       ]
     },
     {

--- a/spec/classes/python_spec.rb
+++ b/spec/classes/python_spec.rb
@@ -63,14 +63,10 @@ describe 'python' do
             :pip => false,
           }}
 
-          case facts[:kernel]
-          when 'Linux'
-            case facts[:operatingsystemmajrelease]
-            when '8'
-              it { is_expected.to contain_package('virtualenv') }
-            else
-              it { is_expected.to contain_package('python-virtualenv') }
-            end
+          case facts[:operatingsystem]
+          when 'Debian'
+            it { is_expected.to contain_package('python-virtualenv') }
+
           when 'FreeBSD'
             it { is_expected.to contain_package('py27-virtualenv') }
           else
@@ -172,9 +168,7 @@ describe 'python' do
           when 'RedHat'
             case facts[:operatingsystemmajrelease]
             when '7'
-              it { is_expected.to contain_package('python-pip') }
-            else
-              it { is_expected.to contain_package('python3-pip') }
+              it { is_expected.to contain_exec('install_pip3').with_command('/bin/curl https://bootstrap.pypa.io/get-pip.py | /bin/python3')}
             end
           when 'Debian'
             it { is_expected.to contain_package('python3-pip') }
@@ -198,21 +192,36 @@ describe 'python' do
 
           case facts[:operatingsystem]
           when 'Debian'
+            it { is_expected.to contain_package('python3-virtualenv') }
 
-            case facts[:operatingsystemmajrelease]
-            when '8'
-              it { is_expected.to contain_package('virtualenv') }
-            else
-              it { is_expected.to contain_package('python-virtualenv') }
-
-            end
           when 'FreeBSD'
-            it { is_expected.to contain_package("virtualenv").with_provider('pip') }
+            it { is_expected.to raise_error() }
+
+          when 'RedHat'
+            it { is_expected.to raise_error() }
 
           else
           end
         end
 
+        context 'when virtualenv and pip are enabled' do
+          let(:params) {{
+            :pip => true,
+            :dev => false,
+            :virtualenv => true,
+            :version => three_version,
+          }}
+
+          case facts[:operatingsystem]
+          when 'FreeBSD'
+            it { is_expected.to contain_package("virtualenv").with_provider('pip') }
+
+          when 'RedHat'
+            it { is_expected.to contain_package("virtualenv").with_provider('pip3') }
+
+          else
+          end
+        end
       end
 
     end


### PR DESCRIPTION
This work adjusts the logic for installing pip3 on CentOS7 for the
purpose of creating a virtualenv with python3.  This work was done as
part of installing the following on a new CentOS7 instance:
 * Install python3
 * Install pip3 through curl (terrible)
 * Install virtualenv with pip3
 * Create virtualenv using python3
 * Install pip package into the virtualenv

Here also are a few structural adjustments I hope will improve
readability.