### PR TITLE
Update the pip installation on FreeBSD

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,11 @@ before_install:
   - rm Gemfile.lock || true
   - gem update bundler
 rvm:
-  - 2.0.0
-  - 2.1.0
+  - 2.0
+  - 2.1
+  - 2.2
 script: bundle exec rake test --trace
 env:
   - PUPPET_VERSION="~> 4.4.0" STRICT_VARIABLES=yes
+  - PUPPET_VERSION="~> 4.5.0" STRICT_VARIABLES=yes
+  - PUPPET_VERSION="~> 4.6.1" STRICT_VARIABLES=yes

--- a/functions/ensure_pip.pp
+++ b/functions/ensure_pip.pp
@@ -1,24 +1,9 @@
 function python::ensure_pip($ensure) {
 
+
   $pip_name = python::pip_name()
 
   case $facts['osfamily'] {
-    'FreeBSD': {
-      if $ensure == present and $::python::version =~ /^3/ {
-        # https://docs.python.org/3.4/library/ensurepip.html
-        exec { 'install_pip3':
-          command => '/usr/local/bin/python3 -m ensurepip',
-          creates => '/usr/local/bin/pip3',
-          require => Package[$python::install::python_name],
-        }
-
-        file { '/usr/local/bin/pip':
-          ensure  => link,
-          target  => '/usr/local/bin/pip3',
-          require => Exec['install_pip3'],
-        }
-      }
-    }
     'RedHat': {
       if $ensure == present {
         if $python::use_epel == true {

--- a/functions/pip_name.pp
+++ b/functions/pip_name.pp
@@ -5,7 +5,7 @@ function python::pip_name() {
     'Linux': {
       if $::python::version == 'system' {
         $pip_name = 'python-pip'
-      } elsif $::python::version =~ /^3/ {
+      } elsif $::python::version =~ /^3.*/ {
         if $facts['osfamily'] == 'RedHat' {
           # As of 2016-05-31 RedHat osfamilies curl get-pip.py to install python3
           $pip_name = undef
@@ -17,8 +17,8 @@ function python::pip_name() {
       }
     }
     'FreeBSD': {
-      if $::python::version == 'system' or $::python::version =~ /^2/ {
-        $pip_name = 'py27-pip'
+      if $::python::version == 'system' or $::python::version =~ /^[23].*/ {
+        $pip_name = "py${::python::version}-pip"
       } else {
         $pip_name = undef
       }

--- a/spec/classes/python_spec.rb
+++ b/spec/classes/python_spec.rb
@@ -173,8 +173,8 @@ describe 'python' do
           when 'Debian'
             it { is_expected.to contain_package('python3-pip') }
           when 'FreeBSD'
-            it { is_expected.to contain_exec('install_pip34')}
-            it { is_expected.to_not contain_package("py27-pip") }
+            #it { is_expected.to contain_exec('install_pip34')}
+            it { is_expected.to_not contain_package("py34-pip") }
           else
             it { is_expected.to_not contain_package('py27-pip') }
             it { is_expected.to_not contain_package('python-pip') }


### PR DESCRIPTION
Drop the hacky exec to install pip for python3 versions on FreebSD.
This work replaces the exec with a package installation matching the
version of the default system python.

Setting DEFAULT_VERSION for python on a FreeBSD system allows the py-pip
package to be built into a name like py35-pip when the default version
is set to 35.  This work ensures that we use the package in place of the
curl.

There may be nuances around trying to instal multiple versions of pip
on the same system.