### PR TITLE
Fix testing for FreeBSD

### DIFF
--- a/functions/ensure_virtualenv.pp
+++ b/functions/ensure_virtualenv.pp
@@ -3,18 +3,7 @@ function python::ensure_virtualenv($ensure) {
   $virtualenv_name = python::virtualenv_name()
 
   if $virtualenv_name {
-    if $facts['osfamily'] == 'FreeBSD' {
-      if $ensure == 'present' {
-        python::require_pip()
-        $pip_name = python::pip_name()
-
-        package { $virtualenv_name:
-          ensure   => $ensure,
-          provider => 'pip',
-          require  => Package[$pip_name],
-        }
-      }
-    } elsif $facts['osfamily'] == 'RedHat' and $::python::version =~ /^3/ {
+    if $facts['osfamily'] == 'RedHat' and $::python::version =~ /^3/ {
       if $ensure == 'present' {
         python::require_pip()
         package { $virtualenv_name:

--- a/functions/pip_name.pp
+++ b/functions/pip_name.pp
@@ -1,6 +1,7 @@
 # This function contains the pip package name determination logic.
 #
 function python::pip_name() {
+
   case $::kernel {
     'Linux': {
       if $::python::version == 'system' {
@@ -17,7 +18,9 @@ function python::pip_name() {
       }
     }
     'FreeBSD': {
-      if $::python::version == 'system' or $::python::version =~ /^[23].*/ {
+      if $::python::version == 'system' {
+        $pip_name = "py27-pip"
+      } elsif $::python::version =~ /^[23].*/ {
         $pip_name = "py${::python::version}-pip"
       } else {
         $pip_name = undef

--- a/functions/virtualenv_name.pp
+++ b/functions/virtualenv_name.pp
@@ -25,10 +25,12 @@ function python::virtualenv_name() {
       }
     }
     'FreeBSD': {
-      if $::python::version =~ /^3/ {
-        $virtualenv_name = 'virtualenv'
+      if $::python::version == 'system' {
+        $pip_name = "py27-virtualenv"
+      } elsif $::python::version =~ /^[23].*/ {
+        $pip_name = "py${::python::version}-virtualenv"
       } else {
-        $virtualenv_name = 'py27-virtualenv'
+        $pip_name = undef
       }
     }
   }

--- a/metadata.json
+++ b/metadata.json
@@ -38,7 +38,7 @@
     {
       "operatingsystem": "FreeBSD",
       "operatingsystemrelease": [
-        "10.3"
+        "10"
       ]
     },
     {

--- a/spec/classes/python_spec.rb
+++ b/spec/classes/python_spec.rb
@@ -173,8 +173,7 @@ describe 'python' do
           when 'Debian'
             it { is_expected.to contain_package('python3-pip') }
           when 'FreeBSD'
-            #it { is_expected.to contain_exec('install_pip34')}
-            it { is_expected.to_not contain_package("py34-pip") }
+            it { is_expected.to contain_package("py34-pip") }
           else
             it { is_expected.to_not contain_package('py27-pip') }
             it { is_expected.to_not contain_package('python-pip') }
@@ -195,7 +194,7 @@ describe 'python' do
             it { is_expected.to contain_package('python3-virtualenv') }
 
           when 'FreeBSD'
-            it { is_expected.to raise_error() }
+            it { is_expected.to contain_package('py34-virtualenv') }
 
           when 'RedHat'
             it { is_expected.to raise_error() }
@@ -214,7 +213,7 @@ describe 'python' do
 
           case facts[:operatingsystem]
           when 'FreeBSD'
-            it { is_expected.to contain_package("virtualenv").with_provider('pip') }
+            it { is_expected.to contain_package("py34-virtualenv") }
 
           when 'RedHat'
             it { is_expected.to contain_package("virtualenv").with_provider('pip3') }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,4 +11,4 @@ RSpec.configure do |c|
   c.manifest_dir = File.join(fixture_path, 'manifests')
 end
 
-
+at_exit { RSpec::Puppet::Coverage.report! }


### PR DESCRIPTION
Without this change, the FreeBSD tests are not actually enabled due to
the facterdb handling of the FreeBSD version in the metadata.  Here we
remove the point release from the FreeBSD version in the metadata,
enabling the tests, and then fix the tests that are broken.