### PR TITLE
Spell OpenBSD with correct capitalization

### DIFF
--- a/spec/classes/python_spec.rb
+++ b/spec/classes/python_spec.rb
@@ -49,7 +49,7 @@ describe 'python' do
           when 'FreeBSD'
             it { is_expected.to contain_package('py27-pip') }
 
-          when 'OpenBSd'
+          when 'OpenBSD'
             it { is_expected.to contain_package('py-pip') }
 
           else


### PR DESCRIPTION
Without this change, the tests may not be completely accurate on
OpenBSD due to a mismatch of capitalization.  Here we correct that to
ensure the desired tests are run.