### PR TITLE
Add data for OpenBSD 6.1

### DIFF
--- a/data/os/OpenBSD/OpenBSD/6.1.yaml
+++ b/data/os/OpenBSD/OpenBSD/6.1.yaml
@@ -1,0 +1,31 @@
+---
+python::version: '3.6.0p0'
+python::valid_versions:
+  - '2.7.13p0'
+  - '3.4.5p2'
+  - '3.5.2p2'
+  - '3.6.0p0'
+
+python::version_data:
+  '3.6.0p0':
+    virtualenv_package: 'py3-virtualenv'
+    virtualenv_cmd: 'virtualenv-3'
+    pip_package: 'py3-pip'
+    pip_cmd: 'pip3.6'
+  '3.5.202':
+    virtualenv_package: 'py3-virtualenv'
+    virtualenv_cmd: 'virtualenv-3'
+    pip_package: 'py3-pip'
+    pip_cmd: 'pip3.5'
+  '3.4.5p2':
+    virtualenv_package: 'py3-virtualenv'
+    virtualenv_cmd: 'virtualenv-3'
+    pip_package: 'py3-pip'
+    pip_cmd: 'pip3.4'
+  '2.7.13p0':
+    virtualenv_package: 'py-virtualenv'
+    virtualenv_cmd: 'virtualenv'
+    pip_package: 'py-pip'
+    pip_cmd: 'pip2.7'
+
+

--- a/spec/version_data.rb
+++ b/spec/version_data.rb
@@ -18,6 +18,9 @@ def three_versions(facts)
       when '6.0'
         '3.5.2'
 
+      when '6.1'
+        '3.6.0p0'
+
       end
     when 'Debian'
       case facts[:operatingsystemmajrelease]
@@ -63,6 +66,9 @@ def two_versions(facts)
 
       when '6.0'
         '2.7.12'
+
+      when '6.1'
+        '2.7.13p0'
 
       end
     when 'Debian'


### PR DESCRIPTION
6.1 looks to include the patch level in the package name according to pkg_info,
so we include the available versions and its data for OpenBSD 6.1.