### PR TITLE
Add support for python 3.6 in CentOS

### DIFF
--- a/data/os/RedHat/CentOS/7.yaml
+++ b/data/os/RedHat/CentOS/7.yaml
@@ -2,3 +2,4 @@
 python::valid_versions:
   - '3'
   - '34'
+  - '36'


### PR DESCRIPTION
Python 3.6 was made the standard EPEL Python 3 version (from 3.4).