### PR TITLE
fix virtualenv_version fact for version 20

### DIFF
--- a/lib/facter/virtualenv_version.rb
+++ b/lib/facter/virtualenv_version.rb
@@ -3,7 +3,7 @@
 Facter.add('virtualenv_version') do
   setcode do
     if Facter::Util::Resolution.which('virtualenv')
-      Facter::Util::Resolution.exec('virtualenv --version 2>&1').match(%r{^(\d+\.\d+\.?\d*).*$})[0]
+      Facter::Util::Resolution.exec('virtualenv --version 2>&1').match(%r{(\d+\.\d+\.?\d*).*$})[1]
     end
   end
 end

--- a/spec/unit/facter/util/fact_virtualenv_version_spec.rb
+++ b/spec/unit/facter/util/fact_virtualenv_version_spec.rb
@@ -7,18 +7,32 @@ describe Facter::Util::Fact do
 
   let(:exec) {}
 
-  let(:virtualenv_version_output) do
+  let(:virtualenv_version_output_old) do
     <<-EOS
 12.0.7
 EOS
   end
 
+  let(:virtualenv_version_output_new) do
+    <<-EOS
+20.0.17
+EOS
+  end
+
   describe 'virtualenv_version' do
-    context 'returns virtualenv version when virtualenv present' do
+    context 'returns virtualenv version when an old virtualenv is present' do
       it do
         allow(Facter::Util::Resolution).to receive(:which).with('virtualenv') { true }
-        allow(Facter::Util::Resolution).to receive(:exec).with('virtualenv --version 2>&1') { virtualenv_version_output }
+        allow(Facter::Util::Resolution).to receive(:exec).with('virtualenv --version 2>&1') { virtualenv_version_output_old }
         Facter.value(:virtualenv_version).should == '12.0.7'
+      end
+    end
+
+    context 'returns virtualenv version when a new virtualenv is present' do
+      it do
+        allow(Facter::Util::Resolution).to receive(:which).with('virtualenv') { true }
+        allow(Facter::Util::Resolution).to receive(:exec).with('virtualenv --version 2>&1') { virtualenv_version_output_new }
+        Facter.value(:virtualenv_version).should == '20.0.17'
       end
     end
 


### PR DESCRIPTION
latest virtualenv is 20.0.23. This version leads to the following error:
```
Error: Facter: error while resolving custom fact "virtualenv_version": undefined method `[]' for nil:NilClass
```

I reproduced it in irb:

```
irb(main):001:0> `virtualenv --version 2>&1`.match(%r{^(\d+\.\d+\.?\d*).*$})
=> nil
irb(main):002:0> `virtualenv --version 2>&1`
=> "virtualenv 20.0.23 from /usr/lib/python3.8/site-packages/virtualenv/__init__.py\n"
irb(main):003:0> `virtualenv --version 2>&1`.match(%r{(\d+\.\d+\.?\d*).*$})
=> #<MatchData "20.0.23 from /usr/lib/python3.8/site-packages/virtualenv/__init__.py" 1:"20.0.23">
irb(main):004:0> `virtualenv --version 2>&1`.match(%r{(\d+\.\d+\.?\d*).*$})[1]
=> "20.0.23"
irb(main):005:0>
```

This code not only fixes it, it's a direct copy from voxpupuli/python.
merging this brings us also closer to solving https://github.com/xaque208/puppet-python/issues/49